### PR TITLE
Pull slack team from config/CLI args

### DIFF
--- a/cmd/gh-slack/main.go
+++ b/cmd/gh-slack/main.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/rneatherway/gh-slack/internal/gh"
 	"github.com/rneatherway/gh-slack/internal/markdown"
@@ -15,6 +16,8 @@ import (
 	"github.com/rneatherway/gh-slack/internal/version"
 
 	"github.com/jessevdk/go-flags"
+
+	github "github.com/cli/go-gh"
 )
 
 var (
@@ -90,7 +93,10 @@ func realMain() error {
 	var team string
 
 	if opts.Team == "" {
-		return errors.New("the required argument `Team` was not provided")
+		team, _, err = getSlackTeam()
+		if err != nil {
+			return errors.New("No team set. Either pass -t/--team or run `gh config set extensions.slack.team team`.")
+		}
 	} else {
 		team = opts.Team
 	}
@@ -154,4 +160,13 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+func getSlackTeam() (string, string, error) {
+	out, stderr, err := github.Exec(
+		"config",
+		"get",
+		"extensions.slack.team",
+	)
+	return strings.TrimRight(string(out.Bytes()), "\n"), string(stderr.Bytes()), err
 }

--- a/cmd/gh-slack/main.go
+++ b/cmd/gh-slack/main.go
@@ -43,6 +43,7 @@ var opts struct {
 	Version bool   `long:"version" description:"Output version information"`
 	Details bool   `short:"d" long:"details" description:"Wrap the markdown output in HTML <details> tags"`
 	Issue   string `short:"i" long:"issue" description:"The URL of a repository to post the output as a new issue, or the URL of an issue to add a comment to that issue"`
+	Team    string `short:"t" long:"team" description:"The slack team name of the workspace you want to use"`
 }
 
 func realMain() error {
@@ -86,8 +87,16 @@ func realMain() error {
 		logger = log.Default()
 	}
 
+	var team string
+
+	if opts.Team == "" {
+		return errors.New("the required argument `Team` was not provided")
+	} else {
+		team = opts.Team
+	}
+
 	client, err := slackclient.New(
-		"github", // This could be made configurable at some point
+		team,
 		logger)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #21 

Slack team can be permanently set by setting `extensions.slack.team`:

```
gh config set extensions.slack.team foo
! warning: 'extensions.slack.team' is not a known configuration key
```

Alternatively it can be passed (or override the default) by setting the `-t` or `--team` flags on the CLI.