### PR TITLE
Update Slack token's macOS keychain account name

### DIFF
--- a/internal/slackclient/cookie_password_macos.go
+++ b/internal/slackclient/cookie_password_macos.go
@@ -10,7 +10,6 @@ import (
 )
 
 func cookiePassword() ([]byte, error) {
-	query := keychain.NewItem()
 	accountNames := []string{"Slack Key", "Slack"}
 
 	var err error
@@ -26,6 +25,7 @@ func cookiePassword() ([]byte, error) {
 }
 
 func cookiePasswordFromKeychain(accountName string) ([]byte, error) {
+	query := keychain.NewItem()
 	query.SetService("Slack Safe Storage")
 	query.SetAccount("Slack Key")
 	query.SetMatchLimit(keychain.MatchLimitOne)

--- a/internal/slackclient/cookie_password_macos.go
+++ b/internal/slackclient/cookie_password_macos.go
@@ -26,6 +26,7 @@ func cookiePassword() ([]byte, error) {
 
 func cookiePasswordFromKeychain(accountName string) ([]byte, error) {
 	query := keychain.NewItem()
+	query.SetSecClass(keychain.SecClassGenericPassword)
 	query.SetService("Slack Safe Storage")
 	query.SetAccount(accountName)
 	query.SetMatchLimit(keychain.MatchLimitOne)

--- a/internal/slackclient/cookie_password_macos.go
+++ b/internal/slackclient/cookie_password_macos.go
@@ -11,7 +11,21 @@ import (
 
 func cookiePassword() ([]byte, error) {
 	query := keychain.NewItem()
-	query.SetSecClass(keychain.SecClassGenericPassword)
+	accountNames := []string{"Slack Key", "Slack"}
+
+	var err error
+	for _, accountName := range accountNames {
+		var password []byte
+		password, err = cookiePasswordFromKeychain(accountName)
+		if err == nil {
+			return password, nil
+		}
+	}
+
+	return []byte{}, err
+}
+
+func cookiePasswordFromKeychain(accountName string) ([]byte, error) {
 	query.SetService("Slack Safe Storage")
 	query.SetAccount("Slack Key")
 	query.SetMatchLimit(keychain.MatchLimitOne)

--- a/internal/slackclient/cookie_password_macos.go
+++ b/internal/slackclient/cookie_password_macos.go
@@ -27,7 +27,7 @@ func cookiePassword() ([]byte, error) {
 func cookiePasswordFromKeychain(accountName string) ([]byte, error) {
 	query := keychain.NewItem()
 	query.SetService("Slack Safe Storage")
-	query.SetAccount("Slack Key")
+	query.SetAccount(accountName)
 	query.SetMatchLimit(keychain.MatchLimitOne)
 	query.SetReturnAttributes(true)
 	query.SetReturnData(true)

--- a/internal/slackclient/cookie_password_macos.go
+++ b/internal/slackclient/cookie_password_macos.go
@@ -13,7 +13,7 @@ func cookiePassword() ([]byte, error) {
 	query := keychain.NewItem()
 	query.SetSecClass(keychain.SecClassGenericPassword)
 	query.SetService("Slack Safe Storage")
-	query.SetAccount("Slack")
+	query.SetAccount("Slack Key")
 	query.SetMatchLimit(keychain.MatchLimitOne)
 	query.SetReturnAttributes(true)
 	query.SetReturnData(true)


### PR DESCRIPTION
It appears that Slack has changed the `Account` value for the keychain item that they use to save the user's token with under macOS.

![image](https://user-images.githubusercontent.com/406937/228380165-4ddbb447-debe-41a3-8148-84cabcac3033.png)
