### PR TITLE
Fix "no user with id [...]" problem in partner channels

### DIFF
--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -72,6 +72,11 @@ type UsersResponse struct {
 	Members []User
 }
 
+type UsersInfoResponse struct {
+	Ok	bool
+	User	User
+}
+
 type Cache struct {
 	Channels map[string]string
 	Users    map[string]string
@@ -395,6 +400,20 @@ func (c *SlackClient) UsernameForID(id string) (string, error) {
 
 	if id, ok := c.cache.Users[id]; ok {
 		return id, nil
+	}
+
+	body, err := c.get("users.info",
+		map[string]string{
+			"user": id})
+	if err == nil {
+		user := &UsersInfoResponse{}
+		err = json.Unmarshal(body, user)
+
+		if err == nil && user.Ok {
+			c.cache.Users[id] = user.User.Name
+			c.saveCache()
+			return user.User.Name, nil
+		}
 	}
 
 	return "", fmt.Errorf("no user with id %q", id)


### PR DESCRIPTION
Today, I tried to download some threads from a partner channel and was greeted by the aforementioned error message instead of any messages.

The reason for this behavior is that, when using partner channels (i.e. [cross-org channels][partner-channels]), the [`users.list`][users-list] request might not return enough information to fill in the user names of the conversation.

Let's use the (slow!) route of [`users.info`][users-info] as a _fall-back_ whenever a user ID is encountered that finds no match in the result of [`users.list`][users-list], still preferring the latter when possible.

[partner-channels]: https://slack.com/resources/using-slack/introducing-your-partners-to-slack-connect
[users-list]: https://api.slack.com/methods/users.list
[users-info]: https://api.slack.com/methods/users.info