### PR TITLE
Add the ability to send messages to a private channel and update help text to use channel name 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project provides a means of archiving a Slack conversation or thread as mar
       gh slack -i <issue-url> <slack-permalink>  # defaults to read command
       gh slack read <slack-permalink>
       gh slack read -i <issue-url> <slack-permalink>
-      gh slack send -m <message> -c <channel-id> -t <team-name>
+      gh slack send -m <message> -c <channel-name> -t <team-name>
 
       # Example configuration (add to gh's configuration file at $HOME/.config/gh/config.yml):
       extensions:

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -23,7 +23,7 @@ var rootCmd = &cobra.Command{
 	Example: `  gh-slack -i <issue-url> <slack-permalink>  # defaults to read command
   gh-slack read <slack-permalink>
   gh-slack read -i <issue-url> <slack-permalink>
-  gh-slack send -m <message> -c <channel-id> -t <team-name>
+  gh-slack send -m <message> -c <channel-name> -t <team-name>
   ` + sendConfigExample,
 }
 

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -326,9 +326,8 @@ func (c *SlackClient) conversations() ([]Channel, error) {
 				"exclude_archived": "true",
 				"limit":            "1000",
 
-				// TODO: this is the default, we might want to support private
-				// channels and DMs in the future
-				"types": "public_channel",
+				// TODO: we might want to support DMs in the future
+				"types": "public_channel, private_channel",
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
This pull request does two things:

1. Adds the ability to send messages to a private channel and thus close rneatherway/gh-slack#50
2. Changes the help text to suggest using the Slack channel name instead of the channel id. I've found this to more reliably work in my usage and testing.

@rneatherway if you want to keep the channel id in the help text, we can drop the commit that changes it ✌️ 