### PR TITLE
feat(command): add api command

### DIFF
--- a/cmd/gh-slack/cmd/api.go
+++ b/cmd/gh-slack/cmd/api.go
@@ -33,7 +33,7 @@ var apiCmd = &cobra.Command{
 		verb := strings.ToUpper(args[0])
 		path := args[1]
 
-		fields, err := cmd.Flags().GetStringSlice("field")
+		fields, err := cmd.Flags().GetStringArray("field")
 		if err != nil {
 			return err
 		}
@@ -69,7 +69,7 @@ var fields []string
 var body string
 
 func init() {
-	apiCmd.Flags().StringSliceVarP(&fields, "field", "f", nil, "Fields to pass to the api call")
+	apiCmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to pass to the api call")
 	apiCmd.Flags().StringVarP(&body, "body", "b", "{}", "Body to send as JSON")
 	apiCmd.Flags().StringP("team", "t", "", "Slack team name (required here or in config)")
 	apiCmd.SetHelpTemplate(apiCmdUsage)

--- a/cmd/gh-slack/cmd/api.go
+++ b/cmd/gh-slack/cmd/api.go
@@ -92,4 +92,32 @@ func mapFields(fields []string) (map[string]string, error) {
 	return mappedFields, nil
 }
 
-const apiCmdUsage string = `TODO`
+const apiCmdUsage string = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}}{{end}}{{if gt (len .Aliases) 0}}
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`

--- a/cmd/gh-slack/cmd/api.go
+++ b/cmd/gh-slack/cmd/api.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/cli/go-gh/pkg/config"
+	"github.com/rneatherway/gh-slack/internal/slackclient"
+	"github.com/spf13/cobra"
+)
+
+var apiCmd = &cobra.Command{
+	Use:   "api verb path",
+	Short: "Send an API call to slack",
+	Long:  "Send an API call to slack",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Read()
+		if err != nil {
+			return err
+		}
+
+		team, err := getFlagOrElseConfig(cfg, cmd.Flags(), "team")
+		if err != nil {
+			return err
+		}
+
+		if len(args) != 2 {
+			return fmt.Errorf("Expected 2 arguments: verb and path, see help")
+		}
+
+		verb := strings.ToUpper(args[0])
+		path := args[1]
+
+		fields, err := cmd.Flags().GetStringSlice("field")
+		if err != nil {
+			return err
+		}
+
+		mappedFields, err := mapFields(fields)
+		if err != nil {
+			return err
+		}
+
+		logger := log.New(io.Discard, "", log.LstdFlags)
+		if verbose {
+			logger = log.Default()
+		}
+
+		client, err := slackclient.New(team, logger)
+		if err != nil {
+			return err
+		}
+
+		response, err := client.API(verb, path, mappedFields, body)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(response))
+		return nil
+	},
+	Example: `  gh-slack api get conversations.list -f types=public_channel,private_channel
+  gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}`,
+}
+
+var fields []string
+var body string
+
+func init() {
+	apiCmd.Flags().StringSliceVarP(&fields, "field", "f", nil, "Fields to pass to the api call")
+	apiCmd.Flags().StringVarP(&body, "body", "b", "{}", "Body to send as JSON")
+	apiCmd.Flags().StringP("team", "t", "", "Slack team name (required here or in config)")
+	apiCmd.SetHelpTemplate(apiCmdUsage)
+	apiCmd.SetUsageTemplate(apiCmdUsage)
+}
+
+func mapFields(fields []string) (map[string]string, error) {
+	mappedFields := map[string]string{}
+
+	for _, field := range fields {
+		parts := strings.SplitN(field, "=", 2)
+
+		if len(parts) != 2 || parts[1] == "" {
+			return nil, fmt.Errorf("field '%s' is missing a value", field)
+		}
+
+		mappedFields[parts[0]] = parts[1]
+	}
+
+	return mappedFields, nil
+}
+
+const apiCmdUsage string = `TODO`

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -41,6 +41,7 @@ var verbose bool = false
 func init() {
 	rootCmd.AddCommand(readCmd)
 	rootCmd.AddCommand(sendCmd)
+	rootCmd.AddCommand(apiCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show verbose debug information")
 	rootCmd.SetHelpTemplate(rootCmdUsageTemplate)
 	rootCmd.SetUsageTemplate(rootCmdUsageTemplate)

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -24,6 +24,7 @@ var rootCmd = &cobra.Command{
   gh-slack read <slack-permalink>
   gh-slack read -i <issue-url> <slack-permalink>
   gh-slack send -m <message> -c <channel-name> -t <team-name>
+  gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}
   ` + sendConfigExample,
 }
 

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -184,6 +184,68 @@ func (c *SlackClient) UsernameForMessage(message Message) (string, error) {
 	return "ghost", nil
 }
 
+func (c *SlackClient) API(verb, path string, params map[string]string, body string) ([]byte, error) {
+	u, err := url.Parse(fmt.Sprintf("https://%s.slack.com/api/", c.team))
+	if err != nil {
+		return nil, err
+	}
+	u.Path += path
+	q := u.Query()
+	for p := range params {
+		q.Add(p, params[p])
+	}
+	u.RawQuery = q.Encode()
+
+	messageBytes := []byte(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal message: %w", err)
+	}
+
+	reqBody := bytes.NewReader(messageBytes)
+
+	resBody := []byte{}
+
+	for {
+		req, err := http.NewRequest(verb, u.String(), reqBody)
+		if err != nil {
+			return nil, err
+		}
+    // FIXME: this doesn't seem to break non-POST/non-data requests, but migth
+    // be polluting the headers.
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.auth.Token))
+		for key := range c.auth.Cookies {
+			req.AddCookie(&http.Cookie{Name: key, Value: c.auth.Cookies[key]})
+		}
+
+		resp, err := httpclient.Client.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		resBody, err = io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == 429 {
+			s, err := strconv.Atoi(resp.Header["Retry-After"][0])
+			if err != nil {
+				return nil, err
+			}
+			d := time.Duration(s)
+			c.log.Printf("rate limited, waiting %ds", d)
+			time.Sleep(d * time.Second)
+		} else if resp.StatusCode >= 300 {
+			return nil, fmt.Errorf("status code %d, headers: %q, body: %q", resp.StatusCode, resp.Header, body)
+		} else {
+			break
+		}
+	}
+
+	return resBody, nil
+}
+
 func (c *SlackClient) get(path string, params map[string]string) ([]byte, error) {
 	u, err := url.Parse(fmt.Sprintf("https://%s.slack.com/api/", c.team))
 	if err != nil {


### PR DESCRIPTION
This adds a more generic way to interact with the slack API, it is a one-stop method that _could_ support any request to the slack API. This means the existing client.get/client.post could be rewritten to use this method.

Adding an API handler goes very much in the `gh api` way as well. Sometimes the helpers aren't enough and proxying to the API is the only real way to make something.

This will need further consideration and documentation writing to explain the different cases and gotchas of using the API directly.


E.g. from https://github.com/rneatherway/gh-slack/issues/53
```shell
ts="$(
  go run cmd/gh-slack/main.go \
    api post chat.postMessage \
    -t XXX \
    -b '{"channel":"YYY","text":"message to pin"}' \
    | jq -r '.ts'
)"

go run cmd/gh-slack/main.go \
  api post pins.add \
  -t XXX \
  -b '{"channel":"YYY","timestamp":"'"${ts}"'"}'
```

Other examples:
```shell
expiration="$(ruby -e 'puts Time.now.to_i + 3*60*60')"
go run cmd/gh-slack/main.go \
	api post users.profile.set \
	-t XXX \
	-b '{"profile": {"status_text": "Eating", "status_emoji": ":broccoli:", "status_expiration": "'"${expiration}"'"}}'
```
