### PR TITLE
Add an auth command

### DIFF
--- a/cmd/gh-slack/cmd/auth.go
+++ b/cmd/gh-slack/cmd/auth.go
@@ -1,0 +1,79 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/cli/go-gh/pkg/config"
+	"github.com/rneatherway/slack"
+	"github.com/spf13/cobra"
+)
+
+var authCmd = &cobra.Command{
+	Use:   "auth [flags]",
+	Short: "Prints authentication information for the Slack API",
+	Long:  `Prints authentication information for the Slack API.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Read()
+		if err != nil {
+			return err
+		}
+
+		team, err := getFlagOrElseConfig(cfg, cmd.Flags(), "team")
+		if err != nil {
+			return err
+		}
+
+		auth, err := slack.GetCookieAuth(team)
+		if err != nil {
+			return err
+		}
+
+		vals := url.Values{}
+		for k, v := range auth.Cookies {
+			vals.Add(k, v)
+		}
+
+		fmt.Printf("export SLACK_TOKEN=%s\n", auth.Token)
+		fmt.Printf("export SLACK_COOKIES=%s\n", vals.Encode())
+		return nil
+	},
+	Example: `  gh-slack auth [-t <team-name>]
+	` + configExample,
+}
+
+func init() {
+	authCmd.Flags().StringP("team", "t", "", "Slack team name (required here or in config)")
+	authCmd.SetUsageTemplate(authCmdUsage)
+	authCmd.SetHelpTemplate(authCmdUsage)
+}
+
+const authCmdUsage string = `Usage:{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}}{{end}}{{if gt (len .Aliases) 0}}
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
+
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+
+{{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+
+Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`

--- a/cmd/gh-slack/cmd/auth.go
+++ b/cmd/gh-slack/cmd/auth.go
@@ -11,8 +11,8 @@ import (
 
 var authCmd = &cobra.Command{
 	Use:   "auth [flags]",
-	Short: "Prints authentication information for the Slack API",
-	Long:  `Prints authentication information for the Slack API.`,
+	Short: "Prints authentication information for the Slack API (treat output as secret)",
+	Long:  "Prints authentication information for the Slack API (treat output as secret).",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := config.Read()
 		if err != nil {
@@ -38,33 +38,42 @@ var authCmd = &cobra.Command{
 		fmt.Printf("export SLACK_COOKIES=%s\n", vals.Encode())
 		return nil
 	},
-	Example: `  gh-slack auth [-t <team-name>]
-	` + configExample,
+	Example: `  eval $(gh-slack auth [-t <team-name>])
+
+  # Example configuration (add to gh's configuration file at $HOME/.config/gh/config.yml):
+  extensions:
+    slack:
+      team: foo`,
 }
 
 func init() {
 	authCmd.Flags().StringP("team", "t", "", "Slack team name (required here or in config)")
-	authCmd.SetUsageTemplate(authCmdUsage)
-	authCmd.SetHelpTemplate(authCmdUsage)
+	authCmd.SetHelpTemplate(authCmdUsageTemplate)
+	authCmd.SetUsageTemplate(authCmdUsageTemplate)
 }
 
-const authCmdUsage string = `Usage:{{if .Runnable}}
-  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
-  {{.CommandPath}}{{end}}{{if gt (len .Aliases) 0}}
+const authCmdUsageTemplate string = `Usage:{{if .Runnable}}
+{{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+{{.CommandPath}}{{end}}{{if gt (len .Aliases) 0}}
 Aliases:
-  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+{{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Security:
+  Treat the output of this command as secret and do not share it with anyone!
+  It can be used to impersonate you. If you suspect it has been compromised,
+  log out of the Slack app to revoke the token and cookies.
 
 Examples:
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}{{$cmds := .Commands}}{{if eq (len .Groups) 0}}
 
-Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
+Available Commands:{{range $cmds}}{{if (or .IsAvailableCommand)}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{else}}{{range $group := .Groups}}
 
 {{.Title}}{{range $cmds}}{{if (and (eq .GroupID $group.ID) (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if not .AllChildCommandsHaveGroup}}
 
 Additional Commands:{{range $cmds}}{{if (and (eq .GroupID "") (or .IsAvailableCommand (eq .Name "help")))}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+{{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
 
 Flags:
 {{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
@@ -73,7 +82,7 @@ Global Flags:
 {{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
 
 Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
-  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+{{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
 
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -3,10 +3,25 @@ package cmd
 import (
 	"os"
 
+	"github.com/cli/go-gh/pkg/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
-const sendConfigExample = `
+func getFlagOrElseConfig(cfg *config.Config, flags *pflag.FlagSet, key string) (string, error) {
+	value, err := flags.GetString(key)
+	if err != nil {
+		return "", err
+	}
+
+	if value != "" {
+		return value, nil
+
+	}
+	return cfg.Get([]string{"extensions", "slack", key})
+}
+
+const configExample = `
   # Example configuration (add to gh's configuration file at $HOME/.config/gh/config.yml):
   extensions:
     slack:
@@ -25,7 +40,7 @@ var rootCmd = &cobra.Command{
   gh-slack read -i <issue-url> <slack-permalink>
   gh-slack send -m <message> -c <channel-name> -t <team-name>
   gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}
-  ` + sendConfigExample,
+  ` + configExample,
 }
 
 func Execute() error {
@@ -43,6 +58,7 @@ func init() {
 	rootCmd.AddCommand(readCmd)
 	rootCmd.AddCommand(sendCmd)
 	rootCmd.AddCommand(apiCmd)
+	rootCmd.AddCommand(authCmd)
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Show verbose debug information")
 	rootCmd.SetHelpTemplate(rootCmdUsageTemplate)
 	rootCmd.SetUsageTemplate(rootCmdUsageTemplate)

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -21,7 +21,7 @@ func getFlagOrElseConfig(cfg *config.Config, flags *pflag.FlagSet, key string) (
 	return cfg.Get([]string{"extensions", "slack", key})
 }
 
-const configExample = `
+const sendConfigEample = `
   # Example configuration (add to gh's configuration file at $HOME/.config/gh/config.yml):
   extensions:
     slack:
@@ -40,7 +40,8 @@ var rootCmd = &cobra.Command{
   gh-slack read -i <issue-url> <slack-permalink>
   gh-slack send -m <message> -c <channel-name> -t <team-name>
   gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}
-  ` + configExample,
+  eval $(gh-slack auth -t <team-name>)
+  ` + sendConfigEample,
 }
 
 func Execute() error {

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -60,7 +60,7 @@ var sendCmd = &cobra.Command{
 	},
 	Example: `  gh-slack send -t <team-name> -c <channel-name> -m <message> -b <bot-name>
   gh-slack send -m <message> -w # If bot is specified in config
-` + configExample,
+` + sendConfigEample,
 }
 
 // sendMessage sends a message to a Slack channel.

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -8,21 +8,7 @@ import (
 	"github.com/cli/go-gh/pkg/config"
 	"github.com/rneatherway/gh-slack/internal/slackclient"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
-
-func getFlagOrElseConfig(cfg *config.Config, flags *pflag.FlagSet, key string) (string, error) {
-	value, err := flags.GetString(key)
-	if err != nil {
-		return "", err
-	}
-
-	if value != "" {
-		return value, nil
-
-	}
-	return cfg.Get([]string{"extensions", "slack", key})
-}
 
 var sendCmd = &cobra.Command{
 	Use:   "send [flags]",
@@ -74,7 +60,7 @@ var sendCmd = &cobra.Command{
 	},
 	Example: `  gh-slack send -t <team-name> -c <channel-name> -m <message> -b <bot-name>
   gh-slack send -m <message> -w # If bot is specified in config
-` + sendConfigExample,
+` + configExample,
 }
 
 // sendMessage sends a message to a Slack channel.


### PR DESCRIPTION
To be used like this:

    eval `gh slack auth`

Then you will have `SLACK_TOKEN` and `SLACK_COOKIES` set in the environment and can (with https://github.com/rneatherway/slack/pull/3) use other slack commands as you wish.

The main use is during development you don't have to keep unlocking the MacOS keychain. "Always allow" doesn't help because the binary changes on every compile.

@nobe4 we discussed this a while back. What do you think?