### PR TITLE
Nicer error message if missing configuration

### DIFF
--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/cli/go-gh/pkg/config"
 	"github.com/spf13/cobra"
@@ -20,12 +22,21 @@ func getFlagOrElseConfig(cfg *config.Config, flags *pflag.FlagSet, key string) (
 
 	}
 
-	s, err := cfg.Get([]string{"extensions", "slack", key})
+	return getGHSlackConfigValue(cfg, key)
+}
+
+func getGHSlackConfigValue(cfg *config.Config, key string) (string, error) {
+	fullKey := []string{"extensions", "slack", key}
+	s, err := cfg.Get(fullKey)
 	if err != nil {
-		err = fmt.Errorf("failed to read gh-slack configuration: %w", err)
+		return "", fmt.Errorf(
+			"failed to read gh-slack configuration value %q from %q: %w",
+			strings.Join(fullKey, "."),
+			filepath.Join(config.ConfigDir(), "config.yml"),
+			err)
 	}
 
-	return s, err
+	return s, nil
 }
 
 const sendConfigEample = `

--- a/cmd/gh-slack/cmd/root.go
+++ b/cmd/gh-slack/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/cli/go-gh/pkg/config"
@@ -18,7 +19,13 @@ func getFlagOrElseConfig(cfg *config.Config, flags *pflag.FlagSet, key string) (
 		return value, nil
 
 	}
-	return cfg.Get([]string{"extensions", "slack", key})
+
+	s, err := cfg.Get([]string{"extensions", "slack", key})
+	if err != nil {
+		err = fmt.Errorf("failed to read gh-slack configuration: %w", err)
+	}
+
+	return s, err
 }
 
 const sendConfigEample = `

--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -46,7 +46,7 @@ var sendCmd = &cobra.Command{
 		}
 
 		if wait && bot == "" {
-			bot, err = cfg.Get([]string{"extensions", "slack", "bot"})
+			bot, err = getGHSlackConfigValue(cfg, "bot")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Wraps the error to give a bit more context, from this:

❯ gh slack auth
Error: could not find key "extensions"

To:

❯ gh slack auth
Error: failed to read gh-slack configuration: could not find key "extensions"