### PR TITLE
Print message permalink after sending

### DIFF
--- a/cmd/gh-slack/cmd/send.go
+++ b/cmd/gh-slack/cmd/send.go
@@ -84,12 +84,11 @@ func sendMessage(team, channelName, message, bot string, logger *log.Logger) err
 		return err
 	}
 
-	// We get back the permalink to the message we just sent, but I don't
-	// currently see a use for that.
-	_, err = client.SendMessage(channelID, message)
+	resp, err := client.SendMessage(channelID, message)
 	if err != nil {
 		return err
 	}
+	fmt.Println(resp.Output(team, channelID))
 
 	if bot != "" {
 		err = rtmClient.ListenForMessagesFromBot(channelID, bot)


### PR DESCRIPTION
## Summary

The `SendMessage` response already contains the timestamp needed to construct a permalink, and the `Output()` helper already formats it. This change captures the response and prints the permalink to stdout so callers can link users to the Slack thread.

### Example output

```
$ gh slack send -m 'deploying foo' -c deploys
Message permalink https://myteam.slack.com/archives/C12345/p1234567890
```

### Use case

After posting a deploy command, link the user to the Slack thread so they can watch for the bot's response.

Addresses #83