### PR TITLE
Remove limit from the replies request

### DIFF
--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -310,7 +310,6 @@ func (c *SlackClient) History(channelID string, startTimestamp string, thread st
 		"channel":   channelID,
 		"ts":        startTimestamp,
 		"inclusive": "true",
-		"limit":     strconv.Itoa(limit),
 	}
 
 	if thread != "" {


### PR DESCRIPTION
We want all messages when fetching a thread. When this _isn't_ a
thread the response is just a single message so this works fine.
