### PR TITLE
Support multipart API file uploads

### DIFF
--- a/cmd/gh-slack/cmd/api.go
+++ b/cmd/gh-slack/cmd/api.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/cli/go-gh/v2/pkg/config"
@@ -31,6 +33,17 @@ var apiCmd = &cobra.Command{
 			return err
 		}
 
+		fileFlags, err := cmd.Flags().GetStringArray("file")
+		if err != nil {
+			return err
+		}
+		if len(fileFlags) > 1 {
+			return fmt.Errorf("only one file upload is supported")
+		}
+		if len(fileFlags) > 0 && body != "" {
+			return fmt.Errorf("--file cannot be used with --body")
+		}
+
 		mappedFields, err := mapFields(fields)
 		if err != nil {
 			return err
@@ -52,7 +65,7 @@ var apiCmd = &cobra.Command{
 			path = args[1]
 		} else if len(args) == 1 {
 			path = args[0]
-			if body == "" {
+			if body == "" && len(fileFlags) == 0 {
 				verb = "GET"
 			} else {
 				verb = "POST"
@@ -61,7 +74,22 @@ var apiCmd = &cobra.Command{
 			return fmt.Errorf("expected 1 or 2 arguments: verb and/or path, see help")
 		}
 
-		response, err := client.API(verb, path, mappedFields, []byte(body))
+		var response []byte
+		if len(fileFlags) > 0 {
+			if verb != "POST" {
+				return fmt.Errorf("--file only supports POST requests")
+			}
+
+			fileParam, file, err := fileParamFromFlag(fileFlags[0])
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			response, err = client.APIMultipart(path, mappedFields, fileParam)
+		} else {
+			response, err = client.API(verb, path, mappedFields, []byte(body))
+		}
 		if err != nil {
 			return err
 		}
@@ -70,15 +98,18 @@ var apiCmd = &cobra.Command{
 		return nil
 	},
 	Example: `  gh-slack api get conversations.list -f types=public_channel,private_channel
-  gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}`,
+  gh-slack api post chat.postMessage -b '{"channel":"123","blocks":[...]}'
+  gh-slack api post users.setPhoto -F image=@photo.jpg -f crop_x=0 -f crop_y=0`,
 }
 
 var fields []string
 var body string
+var files []string
 
 func init() {
 	apiCmd.Flags().StringArrayVarP(&fields, "field", "f", nil, "Fields to pass to the api call")
 	apiCmd.Flags().StringVarP(&body, "body", "b", "", "Body to send as JSON")
+	apiCmd.Flags().StringArrayVarP(&files, "file", "F", nil, "File to upload as multipart form data, in key=@path format")
 	apiCmd.Flags().StringP("team", "t", "", "Slack team name (required here or in config)")
 	apiCmd.SetHelpTemplate(apiCmdUsage)
 	apiCmd.SetUsageTemplate(apiCmdUsage)
@@ -98,6 +129,29 @@ func mapFields(fields []string) (map[string]string, error) {
 	}
 
 	return mappedFields, nil
+}
+
+func fileParamFromFlag(fileFlag string) (slackclient.FileParam, *os.File, error) {
+	parts := strings.SplitN(fileFlag, "=", 2)
+
+	if len(parts) != 2 || parts[0] == "" {
+		return slackclient.FileParam{}, nil, fmt.Errorf("file '%s' must be in key=@path format", fileFlag)
+	}
+	if !strings.HasPrefix(parts[1], "@") || parts[1] == "@" {
+		return slackclient.FileParam{}, nil, fmt.Errorf("file '%s' must be in key=@path format", fileFlag)
+	}
+
+	filePath := strings.TrimPrefix(parts[1], "@")
+	file, err := os.Open(filePath)
+	if err != nil {
+		return slackclient.FileParam{}, nil, fmt.Errorf("opening file %q: %w", filePath, err)
+	}
+
+	return slackclient.FileParam{
+		Fieldname: parts[0],
+		Filename:  filepath.Base(filePath),
+		Reader:    file,
+	}, file, nil
 }
 
 const apiCmdUsage string = `Usage:{{if .Runnable}}

--- a/cmd/gh-slack/cmd/api_test.go
+++ b/cmd/gh-slack/cmd/api_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestMapFields(t *testing.T) {
+	fields, err := mapFields([]string{"channel=C123", "text=hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fields["channel"] != "C123" || fields["text"] != "hello" {
+		t.Fatalf("unexpected fields: %+v", fields)
+	}
+}
+
+func TestMapFieldsMissingValue(t *testing.T) {
+	if _, err := mapFields([]string{"channel="}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFileParamFromFlag(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "photo-*.jpg")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tmp.WriteString("image"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmp.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	param, file, err := fileParamFromFlag("image=@" + tmp.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer file.Close()
+
+	if param.Fieldname != "image" {
+		t.Fatalf("unexpected field name: %s", param.Fieldname)
+	}
+	if param.Filename == "" {
+		t.Fatal("expected filename")
+	}
+	data, err := io.ReadAll(param.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "image" {
+		t.Fatalf("unexpected file data: %q", data)
+	}
+}
+
+func TestFileParamFromFlagInvalidFormat(t *testing.T) {
+	for _, fileFlag := range []string{"image=photo.jpg", "image=@", "=@photo.jpg", "image"} {
+		if _, _, err := fileParamFromFlag(fileFlag); err == nil {
+			t.Fatalf("expected error for %q", fileFlag)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/cli/go-gh/v2 v2.12.2
-	github.com/rneatherway/slack v0.0.0-20241101104547-9d405489f5bc
+	github.com/rneatherway/slack v0.0.0-20260520154001-5e09d7d58326
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/pflag v1.0.5
 	nhooyr.io/websocket v1.8.7

--- a/go.sum
+++ b/go.sum
@@ -136,8 +136,8 @@ github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJ
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=
 github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/rneatherway/slack v0.0.0-20241101104547-9d405489f5bc h1:WZ8peXmqTjLUqjvfxwBoGm7C/wU0Pav7Kid2uzhrW1M=
-github.com/rneatherway/slack v0.0.0-20241101104547-9d405489f5bc/go.mod h1:2WA0D8ytQf+d/hE4QqppWRjFOz86WFG6XX8rpsRLHT8=
+github.com/rneatherway/slack v0.0.0-20260520154001-5e09d7d58326 h1:pzgDUkOdonEdwB0UIt+CwSs7evW0z9A4+epttxssYGc=
+github.com/rneatherway/slack v0.0.0-20260520154001-5e09d7d58326/go.mod h1:a7NHISOQMnmoo1vTsg0XxBVYV+kVNrNT32//2Nm0/W8=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=
 github.com/spf13/cobra v1.6.1/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=

--- a/internal/slackclient/client.go
+++ b/internal/slackclient/client.go
@@ -189,6 +189,12 @@ func (c *SlackClient) API(verb, path string, params map[string]string, body []by
 	return c.client.API(context.TODO(), verb, path, params, body)
 }
 
+type FileParam = slack.FileParam
+
+func (c *SlackClient) APIMultipart(path string, params map[string]string, file FileParam) ([]byte, error) {
+	return c.client.APIMultipart(context.TODO(), path, params, file)
+}
+
 func (c *SlackClient) get(path string, params map[string]string) ([]byte, error) {
 	return c.API("GET", path, params, []byte("{}"))
 }


### PR DESCRIPTION
Closes #89

## Summary
- add `gh-slack api --file/-F key=@path` for multipart file uploads
- send existing `-f/--field` values as multipart form fields when a file is provided
- update `github.com/rneatherway/slack` to the version with `APIMultipart`

## Tests
- `go test ./...`


cc @rneatherway 🙇 